### PR TITLE
add: desp in params,result exception handling, send_text can accept list as pushkey

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests>=2.25.1
-parametrize~=0.1.1
 setuptools~=57.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.25.1
-setuptools~=57.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests>=2.25.1
+parametrize~=0.1.1
+setuptools~=57.0.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="PushDeer for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    
+
     url="https://github.com/gaoliang/pypushdeer",
     project_urls={
         "Bug Tracker": "https://github.com/gaoliang/pypushdeer/issues",

--- a/src/pypushdeer/pypushdeer.py
+++ b/src/pypushdeer/pypushdeer.py
@@ -60,7 +60,6 @@ class PushDeer:
             except IndexError:
                 raise "pypushdeer did not receive result, send may failed"
 
-
     def send_markdown(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
                       pushkey: Optional[str] = None):
         if not pushkey and not self.pushkey:

--- a/src/pypushdeer/pypushdeer.py
+++ b/src/pypushdeer/pypushdeer.py
@@ -1,17 +1,14 @@
 import json
 from typing import Optional
-
 import requests
 
 
 class PushDeer:
     server = "https://api2.pushdeer.com"
-
     endpoint = "/message/push"
-
     pushkey = None
-
     result = None
+    type = 'markdown'
 
     def __init__(self, server: Optional[str] = None, pushkey: Optional[str] = None):
         if server:
@@ -19,8 +16,16 @@ class PushDeer:
         if pushkey:
             self.pushkey = pushkey
 
-    def send_text(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
-                  pushkey: Optional[str or list] = None):
+    def push(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
+             pushkey: Optional[str or list] = None):
+        """
+        Basic method of calling /message/push API
+        @param text:
+        @param desp:
+        @param server:
+        @param pushkey:
+        @return:
+        """
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")
         if type(pushkey) is list:
@@ -29,7 +34,7 @@ class PushDeer:
                 r = requests.get(server or self.server + self.endpoint, params={
                     "pushkey": self.pushkey or key,
                     "text": text,
-                    "type": "text",
+                    "type": self.type,
                     "desp": desp,
                 })
                 try:
@@ -48,7 +53,7 @@ class PushDeer:
             r = requests.get(server or self.server + self.endpoint, params={
                 "pushkey": self.pushkey or pushkey,
                 "text": text,
-                "type": "text",
+                "type": self.type,
                 "desp": desp,
             })
             try:
@@ -60,27 +65,41 @@ class PushDeer:
             except IndexError:
                 raise "pypushdeer did not receive result, send may failed"
 
+    def send_text(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
+                  pushkey: Optional[str or list] = None):
+        """
+        Any text are accepted when type is text.
+        @param text: message : text
+        @param desp: the second part of the message
+        @param server: optional server http address
+        @param pushkey: PushDeer pushkeys, multiple pushkey use list of string, single pushkey use string
+        @return: Boolean
+        """
+        self.type = 'text'
+        return self.push(text=text, desp=desp, server=server, pushkey=pushkey)
+
     def send_markdown(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
-                      pushkey: Optional[str] = None):
-        if not pushkey and not self.pushkey:
-            raise ValueError("pushkey must be specified")
+                      pushkey: Optional[str or list] = None):
+        """
+        Text in Markdown format are accepted when type is markdown.
+        @param text: message : text in Markdown
+        @param desp: the second part of the message
+        @param server: optional server http address
+        @param pushkey: PushDeer pushkeys, multiple pushkey use list of string, single pushkey use string
+        @return: Boolean
+        """
+        self.type = 'markdown'
+        return self.push(text=text, desp=desp, server=server, pushkey=pushkey)
 
-        requests.get(server or self.server + self.endpoint, params={
-            "pushkey": self.pushkey or pushkey,
-            "text": text,
-            "type": "markdown",
-            "desp": desp,
-        })
-
-    def send_image(self, image_url_or_base64: str, desp: Optional[str] = None, server: Optional[str] = None,
-                   pushkey: Optional[str] = None):
-
-        if not pushkey and not self.pushkey:
-            raise ValueError("pushkey must be specified")
-
-        requests.get(server or self.server + self.endpoint, params={
-            "pushkey": self.pushkey or pushkey,
-            "text": image_url_or_base64,
-            "type": "image",
-            "desp": desp,
-        })
+    def send_image(self, image_url: str, desp: Optional[str] = None, server: Optional[str] = None,
+                   pushkey: Optional[str or list] = None):
+        """
+        Only image url are accepted by API now, when type is image.
+        @param image_url: message : image URL
+        @param desp: the second part of the message
+        @param server: optional server http address
+        @param pushkey: PushDeer pushkeys, multiple pushkey use list of string, single pushkey use string
+        @return: Boolean
+        """
+        self.type = 'image'
+        return self.push(text=image_url, desp=desp, server=server, pushkey=pushkey)

--- a/src/pypushdeer/pypushdeer.py
+++ b/src/pypushdeer/pypushdeer.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Optional, Union
 import requests
 
 
@@ -15,7 +15,7 @@ class PushDeer:
             self.pushkey = pushkey
 
     def push(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
-             pushkey: Optional[str or list] = None, text_type: Optional[str] = None):
+             pushkey: Union[str, list, None] = None, text_type: Optional[str] = None):
         """
         Basic method of calling /message/push API
         @param text_type:
@@ -31,28 +31,28 @@ class PushDeer:
             count = 0
             for key in pushkey:
                 r_json = self.send_push_request(desp, key, server, text, text_type)
-                try:
+                if r_json["content"]["result"]:
                     result = json.loads(r_json["content"]["result"][0])
                     if result["success"] == 'ok':
                         count += 1
                     else:
                         pass
-                except IndexError:
-                    raise "pypushdeer did not receive result, send may failed"
+                else:
+                    return False
             if count == len(pushkey):
                 return True
             else:
                 return False
         else:
             r_json = self.send_push_request(desp, pushkey, server, text, text_type)
-            try:
+            if r_json["content"]["result"]:
                 result = json.loads(r_json["content"]["result"][0])
                 if result["success"] == "ok":
                     return True
                 else:
                     return False
-            except IndexError:
-                raise "pypushdeer did not receive result, send may failed"
+            else:
+                return False
 
     def send_push_request(self, desp, key, server, text, text_type):
         return requests.get(server or self.server + self.endpoint, params={
@@ -63,7 +63,7 @@ class PushDeer:
         }).json()
 
     def send_text(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
-                  pushkey: Optional[str or list] = None):
+                  pushkey: Union[str, list, None] = None):
         """
         Any text are accepted when type is text.
         @param text: message : text
@@ -75,7 +75,7 @@ class PushDeer:
         return self.push(text=text, desp=desp, server=server, pushkey=pushkey, text_type='text')
 
     def send_markdown(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
-                      pushkey: Optional[str or list] = None):
+                      pushkey: Union[str, list, None] = None):
         """
         Text in Markdown format are accepted when type is markdown.
         @param text: message : text in Markdown
@@ -87,7 +87,7 @@ class PushDeer:
         return self.push(text=text, desp=desp, server=server, pushkey=pushkey, text_type='markdown')
 
     def send_image(self, image_url: str, desp: Optional[str] = None, server: Optional[str] = None,
-                   pushkey: Optional[str or list] = None):
+                   pushkey: Union[str, list, None] = None):
         """
         Only image url are accepted by API now, when type is image.
         @param image_url: message : image URL

--- a/src/pypushdeer/pypushdeer.py
+++ b/src/pypushdeer/pypushdeer.py
@@ -16,27 +16,29 @@ class PushDeer:
         if pushkey:
             self.pushkey = pushkey
 
-    def send_text(self, text: str, server: Optional[str] = None, pushkey: Optional[str] = None):
+    def send_text(self, text: str, desp: Optional[str] = None, server: Optional[str] = None, pushkey: Optional[str] = None):
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")
 
         requests.get(server or self.server + self.endpoint, params={
             "pushkey": self.pushkey or pushkey,
             "text": text,
-            "type": "text"
+            "type": "text",
+            "desp": desp,
         })
 
-    def send_markdown(self, text: str, server: Optional[str] = None, pushkey: Optional[str] = None):
+    def send_markdown(self, text: str, desp: Optional[str] = None, server: Optional[str] = None, pushkey: Optional[str] = None):
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")
 
         requests.get(server or self.server + self.endpoint, params={
             "pushkey": self.pushkey or pushkey,
             "text": text,
-            "type": "markdown"
+            "type": "markdown",
+            "desp": desp,
         })
 
-    def send_image(self, image_url_or_base64: str, server: Optional[str] = None, pushkey: Optional[str] = None):
+    def send_image(self, image_url_or_base64: str, desp: Optional[str] = None, server: Optional[str] = None, pushkey: Optional[str] = None):
 
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")
@@ -44,5 +46,6 @@ class PushDeer:
         requests.get(server or self.server + self.endpoint, params={
             "pushkey": self.pushkey or pushkey,
             "text": image_url_or_base64,
-            "type": "image"
+            "type": "image",
+            "desp": desp,
         })

--- a/src/pypushdeer/pypushdeer.py
+++ b/src/pypushdeer/pypushdeer.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 
 import requests
@@ -10,24 +11,58 @@ class PushDeer:
 
     pushkey = None
 
+    result = None
+
     def __init__(self, server: Optional[str] = None, pushkey: Optional[str] = None):
         if server:
             self.server = server
         if pushkey:
             self.pushkey = pushkey
 
-    def send_text(self, text: str, desp: Optional[str] = None, server: Optional[str] = None, pushkey: Optional[str] = None):
+    def send_text(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
+                  pushkey: Optional[str or list] = None):
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")
+        if type(pushkey) is list:
+            count = 0
+            for key in pushkey:
+                r = requests.get(server or self.server + self.endpoint, params={
+                    "pushkey": self.pushkey or key,
+                    "text": text,
+                    "type": "text",
+                    "desp": desp,
+                })
+                try:
+                    self.result = json.loads(json.loads(r.text)["content"]["result"][0])
+                    if self.result["success"] == 'ok':
+                        count += 1
+                    else:
+                        pass
+                except IndexError:
+                    raise "pypushdeer did not receive result, send may failed"
+            if count == len(pushkey):
+                return True
+            else:
+                return False
+        else:
+            r = requests.get(server or self.server + self.endpoint, params={
+                "pushkey": self.pushkey or pushkey,
+                "text": text,
+                "type": "text",
+                "desp": desp,
+            })
+            try:
+                self.result = json.loads(json.loads(r.text)["content"]["result"][0])
+                if self.result["success"] == "ok":
+                    return True
+                else:
+                    return False
+            except IndexError:
+                raise "pypushdeer did not receive result, send may failed"
 
-        requests.get(server or self.server + self.endpoint, params={
-            "pushkey": self.pushkey or pushkey,
-            "text": text,
-            "type": "text",
-            "desp": desp,
-        })
 
-    def send_markdown(self, text: str, desp: Optional[str] = None, server: Optional[str] = None, pushkey: Optional[str] = None):
+    def send_markdown(self, text: str, desp: Optional[str] = None, server: Optional[str] = None,
+                      pushkey: Optional[str] = None):
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")
 
@@ -38,7 +73,8 @@ class PushDeer:
             "desp": desp,
         })
 
-    def send_image(self, image_url_or_base64: str, desp: Optional[str] = None, server: Optional[str] = None, pushkey: Optional[str] = None):
+    def send_image(self, image_url_or_base64: str, desp: Optional[str] = None, server: Optional[str] = None,
+                   pushkey: Optional[str] = None):
 
         if not pushkey and not self.pushkey:
             raise ValueError("pushkey must be specified")

--- a/test/test_pypushdeer.py
+++ b/test/test_pypushdeer.py
@@ -1,17 +1,28 @@
+import base64
 from unittest import TestCase
+from parametrize import parametrize
 
 
 class TestPushDeer(TestCase):
-    def test_send_text(self):
-        keys = ['key1', 'key2']
-
+    @parametrize('key', ['key1', 'key2'])
+    def test_send_text(self, key):
         from pypushdeer import PushDeer
         pushdeer = PushDeer()
-        self.assertTrue(pushdeer.send_text("hello world", pushkey=keys))
-        self.assertTrue(pushdeer.send_text("hello world", pushkey=keys[0]))
+        # self.assertTrue(pushdeer.send_text("text list test", pushkey=key))
+        self.assertTrue(pushdeer.send_text("text test", pushkey=key))
 
-    def test_send_markdown(self):
-        self.fail()
+    @parametrize('key', ['key1', 'key2'])
+    def test_send_markdown(self,key):
+        from pypushdeer import PushDeer
+        pushdeer = PushDeer()
+        # self.assertTrue(pushdeer.send_markdown("# markdown list test", pushkey=key))
+        self.assertTrue(pushdeer.send_markdown("# markdown test", pushkey=key))
+
 
     def test_send_image(self):
-        self.fail()
+        from pypushdeer import PushDeer
+        pushdeer = PushDeer()
+        img = "https://www.bing.com/th?id=OHR.SpeloncatoSnow_ROW4998498676_1920x1200.jpg&rf=LaDigue_1920x1200.jpg"
+        # with open("img.png","rb") as f:
+        #     img = base64.b64encode(f.read())
+        self.assertTrue(pushdeer.send_image(image_url=img, pushkey="key"))

--- a/test/test_pypushdeer.py
+++ b/test/test_pypushdeer.py
@@ -16,10 +16,8 @@ class TestPushDeer(TestCase):
         from pypushdeer import PushDeer
         pushdeer = PushDeer()
         pushdeer.send_push_request = mock.Mock(return_value=fail)
-        with self.assertRaises(TypeError):
-            pushdeer.send_text("text list test", pushkey=['key1', 'key2'])
-        with self.assertRaises(TypeError):
-            pushdeer.send_text("text test", pushkey='key')
+        self.assertFalse(pushdeer.send_text("text list test", pushkey=['key1', 'key2']))
+        self.assertFalse(pushdeer.send_text("text test", pushkey='key'))
         pushdeer.send_push_request = mock.Mock(return_value=success)
         with self.assertRaises(ValueError):
             pushdeer.send_text("no pushkey")

--- a/test/test_pypushdeer.py
+++ b/test/test_pypushdeer.py
@@ -1,28 +1,25 @@
-import base64
-from unittest import TestCase
-from parametrize import parametrize
+from unittest import TestCase, mock
+
+success = {'code': 0, 'content': {'result': ['{"counts":1,"logs":[],"success":"ok"}']}}
+fail = {'code': 0, 'content': {'result': []}}
 
 
 class TestPushDeer(TestCase):
-    @parametrize('key', ['key1', 'key2'])
-    def test_send_text(self, key):
+    def test_send_text_success(self):
         from pypushdeer import PushDeer
         pushdeer = PushDeer()
-        # self.assertTrue(pushdeer.send_text("text list test", pushkey=key))
-        self.assertTrue(pushdeer.send_text("text test", pushkey=key))
+        pushdeer.send_push_request = mock.Mock(return_value=success)
+        self.assertTrue(pushdeer.send_text("text list test", pushkey=['key1', 'key2']))
+        self.assertTrue(pushdeer.send_text("text test", pushkey='key'))
 
-    @parametrize('key', ['key1', 'key2'])
-    def test_send_markdown(self,key):
+    def test_send_text_fail(self):
         from pypushdeer import PushDeer
         pushdeer = PushDeer()
-        # self.assertTrue(pushdeer.send_markdown("# markdown list test", pushkey=key))
-        self.assertTrue(pushdeer.send_markdown("# markdown test", pushkey=key))
-
-
-    def test_send_image(self):
-        from pypushdeer import PushDeer
-        pushdeer = PushDeer()
-        img = "https://www.bing.com/th?id=OHR.SpeloncatoSnow_ROW4998498676_1920x1200.jpg&rf=LaDigue_1920x1200.jpg"
-        # with open("img.png","rb") as f:
-        #     img = base64.b64encode(f.read())
-        self.assertTrue(pushdeer.send_image(image_url=img, pushkey="key"))
+        pushdeer.send_push_request = mock.Mock(return_value=fail)
+        with self.assertRaises(TypeError):
+            pushdeer.send_text("text list test", pushkey=['key1', 'key2'])
+        with self.assertRaises(TypeError):
+            pushdeer.send_text("text test", pushkey='key')
+        pushdeer.send_push_request = mock.Mock(return_value=success)
+        with self.assertRaises(ValueError):
+            pushdeer.send_text("no pushkey")

--- a/test/test_pypushdeer.py
+++ b/test/test_pypushdeer.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+
+class TestPushDeer(TestCase):
+    def test_send_text(self):
+        keys = ['key1', 'key2']
+
+        from pypushdeer import PushDeer
+        pushdeer = PushDeer()
+        self.assertTrue(pushdeer.send_text("hello world", pushkey=keys))
+        self.assertTrue(pushdeer.send_text("hello world", pushkey=keys[0]))
+
+    def test_send_markdown(self):
+        self.fail()
+
+    def test_send_image(self):
+        self.fail()


### PR DESCRIPTION
1. 试改了send_text的返回值，解析请求的text判断是否成功。这样方便测试，测试需要给测试方法提供pushkey，目前想到的方法只能这样简单校验result。
2. 添加了desp值的支持。
3. 对send_text添加了多个key的支持，但是这样可能存在效率问题。